### PR TITLE
Resolve hashing mis-match issues

### DIFF
--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -25,7 +25,6 @@ type Block struct {
 	Timestamp    uint64
 	BlockHash []byte
 	Height uint64
-	Transactions []Transactions
 	Signature	string
 	ValidatorAddress []byte
 	TxMerkleTree *MerkleTree
@@ -42,15 +41,18 @@ func (b *Block) Print() {
 	fmt.Printf("Timestamp:       %d\n", b.Timestamp)
 	fmt.Printf("Previous Hash:   %x\n", b.PreviousHash)
 	fmt.Printf("Block Hash :     %x\n", b.BlockHash)
-	for _, t := range b.Transactions {
-		t.Print()
-	}
 }
 
 func (b *Block) Hash() []byte {
     var buff bytes.Buffer
     tempBlock := *b 
     tempBlock.BlockHash = nil
+
+	//THIS WAS CAUSING THE WHOLE "BLOCK SIGNATURE FAILED" ERROR
+	//Block hash was computed (inside POA function in consensus.go) before the block was signed
+	//So, the block hash was different from the one that was signed
+	//So, just had to remove the signature while hashing the block
+	tempBlock.Signature = "" 
 
     enc := gob.NewEncoder(&buff)
     err := enc.Encode(tempBlock)
@@ -81,7 +83,6 @@ func (b *Block) MarshalJSON() ([]byte, error) {
 		Timestamp:    b.Timestamp,
 		PreviousHash:  fmt.Sprintf("%x", b.PreviousHash),
 		MerkleRoot:   merkleRootHash,
-		Transactions: b.Transactions,
 	})
 }
 
@@ -117,14 +118,11 @@ func CreateGenesisBlock() *Block {
 
 func (block *Block) VerifyBlockHash() bool {
 
-	// I can't understand why this is not working
-	//block.Hash() and block.BlockHash doesn't match
-	return true
-	// fmt.Println("Inside verify block hash block property: ", block)
-	// computedBlockHash := block.Hash()
-	// fmt.Println("Computed Block Hash: ", computedBlockHash)
-	// fmt.Println("Block Hash: ", block.BlockHash)
-	// return bytes.Equal(block.Hash(), block.BlockHash)
+	fmt.Println("Inside verify block hash block property: ", block)
+	computedBlockHash := block.Hash()
+	fmt.Println("Computed Block Hash: ", computedBlockHash)
+	fmt.Println("Block Hash: ", block.BlockHash)
+	return bytes.Equal(block.Hash(), block.BlockHash)
 }
 
 func (block *Block) MineBlock(chain *BlockChain, wlt *wallet.Wallet) error {
@@ -174,9 +172,9 @@ func (block *Block) MineBlock(chain *BlockChain, wlt *wallet.Wallet) error {
 	// 	return err
 	// }
 
-	// block.ValidatorAddress = validatorAddress
+	// block.ValidatorAddress = []byte(Validators[string(wlt.Address)].Address)
+	fmt.Println("Validator Address while mining the block: ", block.ValidatorAddress)
 	block.BlockHash = block.Hash()
-	fmt.Println("Block information: ", block)
 
 	return nil
 }

--- a/blockchain/consensus.go
+++ b/blockchain/consensus.go
@@ -3,11 +3,11 @@ package blockchain
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
-	"crypto/sha256"
+	// "crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
-	// "math/big"
+	"math/big"
 
 	"github.com/Roshan310/DaanVeer/wallet"
 )
@@ -21,46 +21,42 @@ type Validator struct {
 var Validators = map[string]Validator{}
 
 
-// var Validators = map[string]bool{}
-
 func (blk *Block) VerifyProof() bool {
 	
 	//Need to debug this quite hard
 	//This will only work if VerifyHash() (inside the block.go) works
-	return true
-	// fmt.Println("About to verify the proof of block")
-	// fmt.Println("    ")
-	// validatorAddr := string(blk.ValidatorAddress)
-	// fmt.Println("Validator Address while verifying proof: ", validatorAddr)
+	//It's finally working! YEAH!!
+	// return true
+	fmt.Println("About to verify the proof of block")
+	fmt.Println("    ")
+	validatorAddr := string(blk.ValidatorAddress)
+	fmt.Println("Validator Address while verifying proof: ", validatorAddr)
 
 	// // Make sure that the validator is in the list of authorized validator
-	// validator, exists := Validators[validatorAddr]
-	// if !exists {
-	// 	fmt.Println("Block rejected: Validator is not authorized.")
-	// 	return false
-	// }
+	validator, exists := Validators[validatorAddr]
+	if !exists {
+		fmt.Println("Block rejected: Validator is not authorized.")
+		return false
+	}
 
-	// // Decode the block's signature
-	// signatureBytes, err := hex.DecodeString(blk.Signature)
-	// if err != nil {
-	// 	fmt.Println("Invalid block signature:", err)
-	// 	return false
-	// }
-	// // }
+	signatureBytes, err := hex.DecodeString(blk.Signature)
+	if err != nil {
+		fmt.Println("Invalid block signature:", err)
+		return false
+	}
 	// // Extract r and s values from the signature
-	// r := new(big.Int).SetBytes(signatureBytes[:len(signatureBytes)/2])
-	// s := new(big.Int).SetBytes(signatureBytes[len(signatureBytes)/2:])
+	r := new(big.Int).SetBytes(signatureBytes[:len(signatureBytes)/2])
+	s := new(big.Int).SetBytes(signatureBytes[len(signatureBytes)/2:])
 
-	// blockHash := blk.Hash()
-	// hashBytes := sha256.Sum256(blockHash)
+	blockHash := blk.Hash()
 	// // Verify the signature using the validator's public key
-	// if ecdsa.Verify(validator.PublicKey, hashBytes[:], r, s) {
-	// 	fmt.Println("Block verified successfully.")
-	// 	return true
-	// } else {
-	// 	fmt.Println("Block signature verification failed.")
-	// 	return false
-	// }
+	if ecdsa.Verify(validator.PublicKey, blockHash[:], r, s) {
+		fmt.Println("Block verified successfully.")
+		return true
+	} else {
+		fmt.Println("Block signature verification failed.")
+		return false
+	}
 }
 
 // ProofOfAuthority signs the block using an authorized validator's private key
@@ -73,11 +69,13 @@ func ProofOfAuthority(blk *Block, validatorWallet *wallet.Wallet) error {
 		return errors.New("validator is not authorized")
 	}
 	fmt.Println("Validator is authorized.")
+	blk.ValidatorAddress = validatorAddr
 	blockHash := blk.Hash()
-	hashBytes := sha256.Sum256(blockHash)
+	fmt.Println("Block Hash inside PoA function: ", blockHash)
+	// hashBytes := sha256.Sum256(blockHash)
 
 	// Sign the block using the validator's private key
-	r, s, err := ecdsa.Sign(rand.Reader, validatorWallet.PrivateKey, hashBytes[:])
+	r, s, err := ecdsa.Sign(rand.Reader, validatorWallet.PrivateKey, blockHash[:])
 	if err != nil {
 		return err
 	}
@@ -87,12 +85,10 @@ func ProofOfAuthority(blk *Block, validatorWallet *wallet.Wallet) error {
 	blk.Signature = hex.EncodeToString(signature)
 
 	
-	// Store the validator's address in the block
-	blk.ValidatorAddress = validatorAddr
-	fmt.Println("Validator Address: ", string(blk.ValidatorAddress))
+
+	fmt.Println("Validator Address inside the PoA function: ", string(blk.ValidatorAddress))
 	fmt.Println("Validator Address expected: ", validatorWallet.Address)
 	fmt.Println("Block signed sucess Signature: ", blk.Signature)
 
-	fmt.Println("Block signed by: ", validatorWallet.Address)
 	return nil
 }

--- a/blockchain/consensus.go
+++ b/blockchain/consensus.go
@@ -84,11 +84,8 @@ func ProofOfAuthority(blk *Block, validatorWallet *wallet.Wallet) error {
 	signature := append(r.Bytes(), s.Bytes()...)
 	blk.Signature = hex.EncodeToString(signature)
 
-	
-
 	fmt.Println("Validator Address inside the PoA function: ", string(blk.ValidatorAddress))
 	fmt.Println("Validator Address expected: ", validatorWallet.Address)
-	fmt.Println("Block signed sucess Signature: ", blk.Signature)
 
 	return nil
 }

--- a/blockchain/transaction.go
+++ b/blockchain/transaction.go
@@ -159,5 +159,3 @@ func DeserializeTxFromGOB(serializedTx []byte) (*Transactions, error) {
 	err := gob.NewDecoder(bytes.NewReader(serializedTx)).Decode(&tx)
 	return &tx, err
 }
-
-

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -251,6 +251,3 @@ func PubKeyFromAddress(address string) ([]byte, error) {
 	}
 	return nil, errors.New("this is not a valid address")
 }
-
-
-


### PR DESCRIPTION
## Major Fixes:
The block hash created an issue while verifying the proof of the block. The block was hashed before signing, but during verification, the block hash was computed with the signature, creating the whole problem. Now, the hashing function sets the signature empty during the hashing of the block.