### PR TITLE
Major Fix

### DIFF
--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"time"
+	"encoding/hex"
 
 	"github.com/Roshan310/DaanVeer/wallet"
 	"github.com/dgraph-io/badger/v4"
@@ -44,24 +45,21 @@ func (b *Block) Print() {
 }
 
 func (b *Block) Hash() []byte {
-    var buff bytes.Buffer
     tempBlock := *b 
     tempBlock.BlockHash = nil
+    tempBlock.Signature = "" 
+    tempBlock.TxMerkleTree = nil
 
-	//THIS WAS CAUSING THE WHOLE "BLOCK SIGNATURE FAILED" ERROR
-	//Block hash was computed (inside POA function in consensus.go) before the block was signed
-	//So, the block hash was different from the one that was signed
-	//So, just had to remove the signature while hashing the block
-	tempBlock.Signature = "" 
-
-    enc := gob.NewEncoder(&buff)
-    err := enc.Encode(tempBlock)
+    // Use JSON instead of gob
+    blockJSON, err := json.Marshal(tempBlock)
     if err != nil {
         fmt.Println("Error while encoding block:", err)
     }
-    hash := sha256.Sum256(buff.Bytes())
+    
+    hash := sha256.Sum256(blockJSON)
     return hash[:]
 }
+
 
 func (b *Block) MarshalJSON() ([]byte, error) {
 	var merkleRootHash string
@@ -117,11 +115,11 @@ func CreateGenesisBlock() *Block {
 }
 
 func (block *Block) VerifyBlockHash() bool {
-
 	fmt.Println("Inside verify block hash block property: ", block)
 	computedBlockHash := block.Hash()
 	fmt.Println("Computed Block Hash: ", computedBlockHash)
-	fmt.Println("Block Hash: ", block.BlockHash)
+	fmt.Println("Block Hash in byte: ", block.BlockHash)
+	fmt.Println("Block Hash in string: ", hex.EncodeToString(block.BlockHash))
 	return bytes.Equal(block.Hash(), block.BlockHash)
 }
 

--- a/blockchain/consensus.go
+++ b/blockchain/consensus.go
@@ -20,6 +20,29 @@ type Validator struct {
 // Validators map now stores validator address and public key
 var Validators = map[string]Validator{}
 
+func init() {
+	authorityAddress := "25ayHZZTtyoMzhNSYwP9ivjpvWABqJw6uhQ9AHoY7eWo1Cb8jT"
+	authorityPubKeyHex := "fb5be55e3b3efa104ee8d2c55407c811af6187681ddcec3de266d39ab8909d80c8fdb4fe2ce1b6c7c6a85f23454e50acdba8f2d4bef022759b6cadee13b6a9de"
+
+	pubKeyBytes, err := hex.DecodeString(authorityPubKeyHex)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to decode public key: %v", err))
+	}
+	
+	pubKey, err := wallet.BytesToPublicKey(pubKeyBytes)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to convert bytes to public key: %v", err))
+	}
+
+	Validators[authorityAddress] = Validator{
+		PublicKey: pubKey,
+		Address:   authorityAddress,
+		authorized: true,
+	}
+
+	fmt.Println("Authority added sucessfully")
+}
+
 
 func (blk *Block) VerifyProof() bool {
 	
@@ -49,7 +72,10 @@ func (blk *Block) VerifyProof() bool {
 	s := new(big.Int).SetBytes(signatureBytes[len(signatureBytes)/2:])
 
 	blockHash := blk.Hash()
+
+	fmt.Println("Block Hash inside verify proof: ", blockHash)
 	// // Verify the signature using the validator's public key
+	fmt.Println("Validator public key: ", validator.PublicKey)
 	if ecdsa.Verify(validator.PublicKey, blockHash[:], r, s) {
 		fmt.Println("Block verified successfully.")
 		return true


### PR DESCRIPTION
New authority has been added which can sign a block. The verification of block hash was failing when the block was sent to other node. The reason was difference in the block hash which was caused by gob encoding. So, while hashing marshal json is used instead of gob encoding. 